### PR TITLE
Use env variable for Apache project path

### DIFF
--- a/docker_controller/.env
+++ b/docker_controller/.env
@@ -1,3 +1,5 @@
+# Nom du conteneur et du dossier du projet
+# Change simplement PROJECT_DIR ici pour configurer un autre projet
 PROJECT_DIR=docker_controller
 MYSQL_ROOT_PASSWORD=root
 DB_PORT=3306

--- a/docker_controller/README.md
+++ b/docker_controller/README.md
@@ -29,34 +29,38 @@ docker compose up -d
 ```
 
 ### Créer un nouveau projet Symfony (si nécessaire)
+Avant de lancer les conteneurs, modifie le fichier `.env` pour définir
+la variable `PROJECT_DIR` avec le nom souhaité.
+
 ```bash
-# Exemple depuis PowerShell
-$env:PROJECT_DIR = "home_controller"
-# Lancer les conteneurs
+# Construction et lancement
 docker compose up -d
-# Créer ensuite ton projet depuis /var/www
-docker exec -w /var/www $env:PROJECT_DIR symfony new --webapp mon_projet
-
-
+# Création du projet Symfony dans le conteneur
+PROJECT=$(grep '^PROJECT_DIR=' .env | cut -d '=' -f2)
+docker exec -w /var/www "$PROJECT" symfony new --webapp "$PROJECT"
 ```
 
 ### Démarrer un nouveau projet
-Change simplement la variable `PROJECT_DIR` pour isoler chaque
-environnement. Chaque valeur de `PROJECT_DIR` possède son propre
-conteneur et son dossier `./<nom>` sur l'hôte :
+Change simplement la variable `PROJECT_DIR` dans `.env` pour isoler chaque
+environnement. Chaque valeur possède son propre conteneur et son dossier
+`./<nom>` sur l'hôte :
 
 ```bash
-$env:PROJECT_DIR = "mon_second_projet"
+# Exemple avec un nouveau projet
+sed -i "s/^PROJECT_DIR=.*/PROJECT_DIR=mon_second_projet/" .env
 docker compose up -d
-docker exec -w /var/www $env:PROJECT_DIR symfony new --webapp mon_projet
+PROJECT=$(grep '^PROJECT_DIR=' .env | cut -d '=' -f2)
+docker exec -w /var/www "$PROJECT" symfony new --webapp "$PROJECT"
 ```
 
 Tu peux ainsi démultiplier les environnements sans rien réinstaller.
+Chaque instance dispose de son propre volume MySQL (`mysql_data_<nom>`),
+ce qui évite les conflits de base de données entre projets.
 
 ### Régler les permissions (optionnel)
 Pour éviter les problèmes de permissions :
 ```bash
-sudo chown -R $USER:$USER project
+sudo chown -R $USER:$USER "$PROJECT"
 ```
 
 ## 2. Structure du projet
@@ -84,7 +88,7 @@ docker compose down
 - **Accéder au conteneur**
 ```bash
 # voir la création de symfony
-docker exec -it $env:PROJECT_DIR bash
+docker exec -it $PROJECT bash
 ```
 - **Voir les logs**
 ```bash
@@ -107,24 +111,24 @@ docker compose logs
 ## 5. Gestion des dépendances avec Composer
 - **Installer les dépendances**
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR composer install
+docker exec -w /var/www/$PROJECT $PROJECT composer install
 ```
 - **Ajouter une nouvelle dépendance (exemple twig)**
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR composer require twig
+docker exec -w /var/www/$PROJECT $PROJECT composer require twig
 ```
 
 ### Monter en version Symfony
 Pour passer à une version plus récente de Symfony :
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR composer update symfony/*
+docker exec -w /var/www/$PROJECT $PROJECT composer update symfony/*
 ```
 
 ## 6. Débogage
 - **Activer la barre de débogage Symfony**
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR composer require symfony/web-profiler-bundle --dev
-docker exec -w /var/www/project $env:PROJECT_DIR bin/console cache:clear
+docker exec -w /var/www/$PROJECT $PROJECT composer require symfony/web-profiler-bundle --dev
+docker exec -w /var/www/$PROJECT $PROJECT bin/console cache:clear
 ```
 
 - **Voir les logs Apache**
@@ -134,41 +138,41 @@ docker exec -it   cat /var/log/apache2/error.log
 
 - **Activer le mode debug Symfony**
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR bin/console debug:config framework
+docker exec -w /var/www/$PROJECT $PROJECT bin/console debug:config framework
 ```
 
 ## 7. Problèmes fréquents
 ### Erreur Doctrine (base de données)
 Vérifier extensions PHP (`pdo_mysql` activée) :
 ```bash
-docker exec -it $env:PROJECT_DIR docker-php-ext-install pdo_mysql
+docker exec -it $PROJECT docker-php-ext-install pdo_mysql
 ```
 Créer la base de données :
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR bin/console doctrine:database:create
+docker exec -w /var/www/$PROJECT $PROJECT bin/console doctrine:database:create
 ```
 
 - **Erreur 404 (Page Not Found)** : Vérifie l'installation Symfony et la configuration Apache (`vhosts.conf`).
 
 - **Problèmes de cache Symfony** : Vider le cache
 ```bash
-docker exec -w /var/www/project $env:PROJECT_DIR bin/console cache:clear
+docker exec -w /var/www/$PROJECT $PROJECT bin/console cache:clear
 ```
 
 - **Problèmes de permissions** :
 ```bash
-sudo chown -R $USER:$USER project
+sudo chown -R $USER:$USER "$PROJECT"
 ```
 
 Remarque : Utilisation du shell interactif Docker
 Lorsque tu accèdes au conteneur Docker via la commande :
 
-docker exec -it $env:PROJECT_DIR bash
-par défaut, tu es situé dans le répertoire /var/www. À cet endroit, le fichier bin/console n'existe pas car ton projet Symfony se trouve dans le sous-dossier /var/www/project.
+docker exec -it $PROJECT bash
+par défaut, tu es situé dans le répertoire /var/www. À cet endroit, le fichier bin/console n'existe pas car ton projet Symfony se trouve dans le sous-dossier /var/www/$PROJECT.
 
 Tu dois donc te déplacer vers le dossier du projet Symfony pour exécuter les commandes Symfony :
 
-cd project
+cd "$PROJECT"
 php bin/console make:controller chatController
 Cette étape est essentielle pour que Symfony reconnaisse tes commandes et les exécute correctement.
 

--- a/docker_controller/compose.yaml
+++ b/docker_controller/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: mysql:8.0
     container_name: db_${PROJECT_DIR}
     volumes:
-      - mysql_data:/var/lib/mysql
+      - mysql_data_${PROJECT_DIR}:/var/lib/mysql
     ports:
       - "${DB_PORT}:3306"
     environment:
@@ -27,7 +27,7 @@ services:
     ports:
       - "${MAILDEV_PORT}:80"
 
- www:
+  www:
     platform: linux/amd64     # change en linux/arm64 si Mac M1/Raspberry
     build:
       context: .                # racine du dépôt
@@ -36,15 +36,14 @@ services:
         GIT_USER_NAME: ${GIT_USER_NAME}
         GIT_USER_EMAIL: ${GIT_USER_EMAIL}
     container_name: ${PROJECT_DIR}
+    environment:
+      PROJECT_DIR: ${PROJECT_DIR}
     ports:
       - "${WWW_PORT}:80"
     volumes:
-      - ./php/vhosts:/etc/apache2/sites-enabled
-      - ./${PROJECT_DIR}:/var/www
+      - ./php/vhosts:/templates:ro
+      - ./${PROJECT_DIR}:/var/www/${PROJECT_DIR}
     restart: always
 
 volumes:
-  mysql_data:
-
-volumes:
-  mysql_data:
+  mysql_data_${PROJECT_DIR}:

--- a/docker_controller/entrypoint.sh
+++ b/docker_controller/entrypoint.sh
@@ -1,23 +1,28 @@
 #!/bin/sh
 set -e
 
-if [ -d "/var/www/app" ]; then
-  mkdir -p /var/www/app/var/cache /var/www/app/var/log
+envsubst '$PROJECT_DIR' < /templates/vhosts.conf > /etc/apache2/sites-enabled/000-default.conf
+
+PROJECT_PATH="/var/www/${PROJECT_DIR}"
+
+if [ -d "$PROJECT_PATH" ]; then
+  mkdir -p "$PROJECT_PATH/var/cache" "$PROJECT_PATH/var/log"
 
   # Récupère UID / GID du code monté
-  HOST_UID=$(stat -c '%u' /var/www/app)
-  HOST_GID=$(stat -c '%g' /var/www/app)
+  HOST_UID=$(stat -c '%u' "$PROJECT_PATH")
+  HOST_GID=$(stat -c '%g' "$PROJECT_PATH")
 
   # ACL : www-data + UID numérique + groupe numérique
   setfacl -R -m u:www-data:rwX \
               -m u:${HOST_UID}:rwX \
               -m g:${HOST_GID}:rwX \
-              /var/www/app/var
+              "$PROJECT_PATH/var"
 
   setfacl -R -d -m u:www-data:rwX \
                 -m u:${HOST_UID}:rwX \
                 -m g:${HOST_GID}:rwX \
-                /var/www/app/var
+                "$PROJECT_PATH/var"
 fi
 
 exec "$@"
+

--- a/docker_controller/php/vhosts/vhosts.conf
+++ b/docker_controller/php/vhosts/vhosts.conf
@@ -1,17 +1,17 @@
 <VirtualHost *:80>
     ServerName localhost
-    DocumentRoot /var/www/app/public
+    DocumentRoot /var/www/${PROJECT_DIR}/public
 
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
-    <Directory /var/www/app/public>
+    <Directory /var/www/${PROJECT_DIR}/public>
         AllowOverride All
         Require all granted
         DirectoryIndex index.php
         FallbackResource /index.php
     </Directory>
 
-    <Directory /var/www/app/public/bundles>
+    <Directory /var/www/${PROJECT_DIR}/public/bundles>
         FallbackResource disabled
     </Directory>
 


### PR DESCRIPTION
## Summary
- make Apache vhost use PROJECT_DIR variable
- template vhost.conf via entrypoint
- mount project directory at /var/www/$PROJECT_DIR
- document using PROJECT_DIR in README

## Testing
- `yamllint docker_controller/compose.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68416662236883269e203783dc524b83